### PR TITLE
fix: clean up all test suite warnings

### DIFF
--- a/src/domain/entities.py
+++ b/src/domain/entities.py
@@ -5,7 +5,7 @@ from decimal import Decimal
 from enum import Enum
 from typing import Optional
 
-from pydantic import BaseModel, Field, HttpUrl
+from pydantic import BaseModel, ConfigDict, Field, HttpUrl
 
 
 class Shop(BaseModel):
@@ -20,8 +20,8 @@ class Shop(BaseModel):
     is_popular: bool = False
     scraped_at: datetime = Field(default_factory=lambda: datetime.now(timezone.utc))
 
-    class Config:
-        json_schema_extra = {
+    model_config = ConfigDict(
+        json_schema_extra={
             "example": {
                 "slug": "biedronka",
                 "brand_id": 23,
@@ -32,7 +32,7 @@ class Shop(BaseModel):
                 "is_popular": True,
             }
         }
-
+    )
 
 class LeafletStatus(str, Enum):
     """Leaflet availability status."""

--- a/src/logging_config.py
+++ b/src/logging_config.py
@@ -46,13 +46,11 @@ def setup_logging() -> None:
     if settings.log_format == "json":
         # JSON output for production
         processors = shared_processors + [
-            structlog.processors.format_exc_info,
             structlog.processors.JSONRenderer(),
         ]
     else:
         # Console output with colors for development
         processors = shared_processors + [
-            structlog.processors.format_exc_info,
             structlog.dev.ConsoleRenderer(colors=True),
         ]
 

--- a/tests/scrapers/test_leaflet_scraper.py
+++ b/tests/scrapers/test_leaflet_scraper.py
@@ -1,6 +1,6 @@
 """Tests for LeafletScraper."""
 
-from datetime import datetime, timedelta
+from datetime import datetime, timedelta, timezone
 from unittest.mock import patch
 
 import pytest
@@ -118,7 +118,7 @@ class TestLeafletScraper:
     def test_extract_leaflet_active_status(self, mock_driver):
         """Test extracting leaflet with active status."""
         # Use naive datetimes to match scraper behavior
-        now = datetime.utcnow()
+        now = datetime.now(timezone.utc).replace(tzinfo=None)
         start = now - timedelta(days=1)
         end = now + timedelta(days=1)
 
@@ -147,7 +147,7 @@ class TestLeafletScraper:
     def test_extract_leaflet_upcoming_status(self, mock_driver):
         """Test extracting leaflet with upcoming status."""
         # Use naive datetimes to match scraper behavior
-        now = datetime.utcnow()
+        now = datetime.now(timezone.utc).replace(tzinfo=None)
         start = now + timedelta(days=5)
         end = now + timedelta(days=12)
 
@@ -176,7 +176,7 @@ class TestLeafletScraper:
     def test_extract_leaflet_archived_status(self, mock_driver):
         """Test extracting leaflet with archived status."""
         # Use naive datetimes to match scraper behavior
-        now = datetime.utcnow()
+        now = datetime.now(timezone.utc).replace(tzinfo=None)
         start = now - timedelta(days=10)
         end = now - timedelta(days=3)
 


### PR DESCRIPTION
Fixes #11

## Summary
Cleaned up all 21 test suite warnings to improve code quality and future compatibility.

## Changes Made

### 1. Pydantic Config Deprecation (1 warning)
- Replaced deprecated `class Config` with `model_config = ConfigDict(...)` in `src/domain/entities.py`

### 2. structlog format_exc_info (~17 warnings)
- Removed deprecated `structlog.processors.format_exc_info` from processor chain in `src/logging_config.py`

### 3. datetime.utcnow() Deprecation (3 warnings)
- Replaced `datetime.utcnow()` with `datetime.now(timezone.utc).replace(tzinfo=None)` in `tests/scrapers/test_leaflet_scraper.py`