### PR TITLE
fix: preserve Pydantic type coercion for nested settings from .env

### DIFF
--- a/src/config.py
+++ b/src/config.py
@@ -64,40 +64,44 @@ class Settings(BaseSettings):
 
         This allows passing values like Settings(request_delay_min=0.5) directly
         while maintaining the nested scraping configuration structure.
+
+        Uses dict-based construction to ensure Pydantic type coercion is applied
+        to values from environment variables and .env files.
         """
+        # Ensure scraping is a dict (not an already-constructed object)
+        # to allow Pydantic to handle type coercion
+        if "scraping" not in values:
+            values["scraping"] = {}
+        elif isinstance(values["scraping"], ScrapingSettings):
+            # Convert existing ScrapingSettings to dict for merging
+            values["scraping"] = values["scraping"].model_dump()
+
         # Handle request_delay_min
         if "request_delay_min" in values and values["request_delay_min"] is not None:
-            if "scraping" not in values:
-                values["scraping"] = ScrapingSettings()
-            values["scraping"].request_delay_min = values.pop("request_delay_min")
+            values["scraping"]["request_delay_min"] = values.pop("request_delay_min")
 
         # Handle request_delay_max
         if "request_delay_max" in values and values["request_delay_max"] is not None:
-            if "scraping" not in values:
-                values["scraping"] = ScrapingSettings()
-            values["scraping"].request_delay_max = values.pop("request_delay_max")
+            values["scraping"]["request_delay_max"] = values.pop("request_delay_max")
 
         # Handle page_load_timeout
         if "page_load_timeout" in values and values["page_load_timeout"] is not None:
-            if "scraping" not in values:
-                values["scraping"] = ScrapingSettings()
-            values["scraping"].page_load_timeout = values.pop("page_load_timeout")
+            values["scraping"]["page_load_timeout"] = values.pop("page_load_timeout")
+
+        # Handle retry settings
+        if "retry" not in values["scraping"]:
+            values["scraping"]["retry"] = {}
+        elif isinstance(values["scraping"].get("retry"), RetrySettings):
+            # Convert existing RetrySettings to dict for merging
+            values["scraping"]["retry"] = values["scraping"]["retry"].model_dump()
 
         # Handle max_retries
         if "max_retries" in values and values["max_retries"] is not None:
-            if "scraping" not in values:
-                values["scraping"] = ScrapingSettings()
-            if not hasattr(values["scraping"], "retry") or values["scraping"].retry is None:
-                values["scraping"].retry = RetrySettings()
-            values["scraping"].retry.max_attempts = values.pop("max_retries")
+            values["scraping"]["retry"]["max_attempts"] = values.pop("max_retries")
 
         # Handle retry_backoff
         if "retry_backoff" in values and values["retry_backoff"] is not None:
-            if "scraping" not in values:
-                values["scraping"] = ScrapingSettings()
-            if not hasattr(values["scraping"], "retry") or values["scraping"].retry is None:
-                values["scraping"].retry = RetrySettings()
-            values["scraping"].retry.backoff_factor = values.pop("retry_backoff")
+            values["scraping"]["retry"]["backoff_factor"] = values.pop("retry_backoff")
 
         return values
 


### PR DESCRIPTION
## Problem

When loading settings from a .env file, string values were not being coerced to their declared types (float, int). This caused 37 tests to fail locally while passing in CI (which has no .env file).

Example:
```python
# .env file contains: REQUEST_DELAY_MIN=0.5
config = Settings()
print(config.request_delay_min)  # '0.5' (str) instead of 0.5 (float)
print(type(config.request_delay_min))  # <class 'str'> instead of <class 'float'>
```

## Analysis

The root cause was in `map_backwards_compatibility_fields` model_validator:

1. The validator created `ScrapingSettings()` and `RetrySettings()` objects directly
2. Used `setattr(obj, field, value)` to mutate nested objects
3. Direct attribute assignment bypasses Pydantic's type coercion
4. String values from .env files remained as strings

The issue only manifested with .env files because constructor arguments and direct env vars are validated through different code paths.

## Solution

Changed the validator to build nested dictionaries instead of objects:

- Build dict structures for nested settings
- Let Pydantic handle type coercion through normal validation
- Handle case where `scraping` or `retry` might already be objects (constructor args)

### Before (broken):
```python
values["scraping"] = ScrapingSettings()  # Creates object
values["scraping"].request_delay_min = values.pop("request_delay_min")  # Bypasses coercion
```

### After (fixed):
```python
values["scraping"] = {}  # Build dict
values["scraping"]["request_delay_min"] = values.pop("request_delay_min")  # Coerced by Pydantic
```

## Verification

Tested with .env file containing string values. All types correctly coerced:
- `request_delay_min`: '0.5' → 0.5 (float) ✓
- `request_delay_max`: '1.5' → 1.5 (float) ✓
- `page_load_timeout`: '60' → 60 (int) ✓
- `max_retries`: '5' → 5 (int) ✓
- `retry_backoff`: '3.0' → 3.0 (float) ✓

Backwards compatibility (direct constructor args) also verified.

## Notes

- No breaking changes to the public API
- Backwards compatibility properties continue to work
- Constructor argument passing unchanged

Fixes #15