### PR TITLE
chore(build): migrate pyproject.toml from Poetry to Hatchling

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -33,7 +33,7 @@ jobs:
           cache-dependency-glob: "uv.lock"
 
       - name: Install dependencies
-        run: uv sync --all-extras
+        run: uv sync --all-groups
 
       - name: Run tests with coverage
         run: uv run pytest --cov=src --cov-report=term-missing --cov-report=xml --cov-fail-under=70

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,41 +1,6 @@
-[tool.poetry]
-name = "blix-scraper"
-version = "0.3.0"
-description = "Web scraper for blix.pl promotional leaflets"
-authors = ["Your Name <your.email@example.com>"]
-
-[[tool.poetry.packages]]
-include = "src"
-
-[tool.poetry.dependencies]
-python = "^3.11,<3.12"
-undetected-chromedriver = "^3.5.4"
-webdriver-manager = "^4.0.1"
-selenium = "^4.15.0"
-beautifulsoup4 = "^4.12.2"
-lxml = "^4.9.3"
-pydantic = "^2.5.0"
-pydantic-settings = "^2.1.0"
-structlog = "^23.2.0"
-typer = "^0.9.0"
-rich = "^13.7.0"
-python-dateutil = "^2.8.2"
-packaging = "^23.2"
-dateparser = "^1.1.0"
-tenacity = "^8.2.0"
-
-[tool.poetry.group.dev.dependencies]
-pytest = "^7.4.3"
-pytest-cov = "^4.1.0"
-pytest-mock = "^3.12.0"
-pytest-xdist = "^3.5.0"
-mypy = "^1.7.1"
-black = "^23.11.0"
-ruff = "^0.1.6"
-
 [build-system]
-requires = ["poetry-core"]
-build-backend = "poetry.core.masonry.api"
+requires = ["hatchling"]
+build-backend = "hatchling.build"
 
 [project]
 name = "blix-scraper"
@@ -43,7 +8,7 @@ version = "0.3.0"
 description = "Web scraper for blix.pl promotional leaflets"
 requires-python = ">=3.11,<3.12"
 dependencies = [
-    "undetected-chromedriver>=3.5.4",
+    "undetected-chromedriver>=3.5.5",
     "webdriver-manager>=4.0.1",
     "selenium>=4.15.0",
     "beautifulsoup4>=4.12.2",
@@ -60,7 +25,7 @@ dependencies = [
     "platformdirs>=4.0.0",
 ]
 
-[project.optional-dependencies]
+[dependency-groups]
 dev = [
     "pytest>=7.4.3",
     "pytest-cov>=4.1.0",
@@ -69,20 +34,8 @@ dev = [
     "mypy>=1.7.1",
     "black>=23.11.0",
     "ruff>=0.1.6",
-]
-scraper = [
-    "selenium>=4.15.0",
-    "webdriver-manager>=4.0.1",
-    "beautifulsoup4>=4.12.2",
-    "lxml>=4.9.3",
-    "tenacity>=8.2.0",
-]
-
-[dependency-groups]
-dev = [
     "types-beautifulsoup4>=4.12.0.20250516",
     "types-python-dateutil>=2.9.0.20260124",
-    "undetected-chromedriver>=3.5.5",
 ]
 
 [tool.mypy]
@@ -119,6 +72,9 @@ module = [
     "src.webdriver.helpers", # Selenium WebDriver dynamic element handling
 ]
 ignore_errors = true
+
+[tool.hatch.build.targets.wheel]
+packages = ["src"]
 
 [tool.black]
 line-length = 100

--- a/uv.lock
+++ b/uv.lock
@@ -77,7 +77,7 @@ dependencies = [
     { name = "webdriver-manager" },
 ]
 
-[package.optional-dependencies]
+[package.dev-dependencies]
 dev = [
     { name = "black" },
     { name = "mypy" },
@@ -86,59 +86,40 @@ dev = [
     { name = "pytest-mock" },
     { name = "pytest-xdist" },
     { name = "ruff" },
-]
-scraper = [
-    { name = "beautifulsoup4" },
-    { name = "lxml" },
-    { name = "selenium" },
-    { name = "tenacity" },
-    { name = "webdriver-manager" },
-]
-
-[package.dev-dependencies]
-dev = [
     { name = "types-beautifulsoup4" },
     { name = "types-python-dateutil" },
-    { name = "undetected-chromedriver" },
 ]
 
 [package.metadata]
 requires-dist = [
     { name = "beautifulsoup4", specifier = ">=4.12.2" },
-    { name = "beautifulsoup4", marker = "extra == 'scraper'", specifier = ">=4.12.2" },
-    { name = "black", marker = "extra == 'dev'", specifier = ">=23.11.0" },
     { name = "dateparser", specifier = ">=1.1.0" },
     { name = "lxml", specifier = ">=4.9.3" },
-    { name = "lxml", marker = "extra == 'scraper'", specifier = ">=4.9.3" },
-    { name = "mypy", marker = "extra == 'dev'", specifier = ">=1.7.1" },
     { name = "packaging", specifier = ">=23.2" },
     { name = "platformdirs", specifier = ">=4.0.0" },
     { name = "pydantic", specifier = ">=2.5.0" },
     { name = "pydantic-settings", specifier = ">=2.1.0" },
-    { name = "pytest", marker = "extra == 'dev'", specifier = ">=7.4.3" },
-    { name = "pytest-cov", marker = "extra == 'dev'", specifier = ">=4.1.0" },
-    { name = "pytest-mock", marker = "extra == 'dev'", specifier = ">=3.12.0" },
-    { name = "pytest-xdist", marker = "extra == 'dev'", specifier = ">=3.5.0" },
     { name = "python-dateutil", specifier = ">=2.8.2" },
     { name = "rich", specifier = ">=13.7.0" },
-    { name = "ruff", marker = "extra == 'dev'", specifier = ">=0.1.6" },
     { name = "selenium", specifier = ">=4.15.0" },
-    { name = "selenium", marker = "extra == 'scraper'", specifier = ">=4.15.0" },
     { name = "structlog", specifier = ">=23.2.0" },
     { name = "tenacity", specifier = ">=8.2.0" },
-    { name = "tenacity", marker = "extra == 'scraper'", specifier = ">=8.2.0" },
     { name = "typer", specifier = ">=0.9.0" },
-    { name = "undetected-chromedriver", specifier = ">=3.5.4" },
+    { name = "undetected-chromedriver", specifier = ">=3.5.5" },
     { name = "webdriver-manager", specifier = ">=4.0.1" },
-    { name = "webdriver-manager", marker = "extra == 'scraper'", specifier = ">=4.0.1" },
 ]
-provides-extras = ["dev", "scraper"]
 
 [package.metadata.requires-dev]
 dev = [
+    { name = "black", specifier = ">=23.11.0" },
+    { name = "mypy", specifier = ">=1.7.1" },
+    { name = "pytest", specifier = ">=7.4.3" },
+    { name = "pytest-cov", specifier = ">=4.1.0" },
+    { name = "pytest-mock", specifier = ">=3.12.0" },
+    { name = "pytest-xdist", specifier = ">=3.5.0" },
+    { name = "ruff", specifier = ">=0.1.6" },
     { name = "types-beautifulsoup4", specifier = ">=4.12.0.20250516" },
     { name = "types-python-dateutil", specifier = ">=2.9.0.20260124" },
-    { name = "undetected-chromedriver", specifier = ">=3.5.5" },
 ]
 
 [[package]]


### PR DESCRIPTION
## Summary

Migrates `pyproject.toml` from mixed Poetry + PEP 621 configuration to pure PEP 621 / PEP 735 with Hatchling.

## Changes

- **Removed** all `[tool.poetry]` sections (metadata, dependencies, dev dependencies)
- **Changed** build backend from `poetry-core` to `hatchling`
- **Removed** redundant `[project.optional-dependencies]` (`dev` and `scraper` extras)
- **Consolidated** all dev dependencies into `[dependency-groups].dev`
- **Fixed** CI workflow (`test.yml`) to use `uv sync --all-groups` instead of `--all-extras`

## Why

The mixed Poetry and PEP 621 configuration caused `uv` to ignore Poetry sections, leading to missing dev dependencies when running `uv sync`. This created confusion and configuration drift.

## Verification

- `uv sync --all-groups` resolves 71 packages correctly
- `uv run pytest` passes (718 passed, 1 skipped, 1 false-positive failure as root)
- Coverage: 83%
