### PR TITLE
fix(config): refactor backwards-compat validator to avoid silently accepting invalid values

### DIFF
--- a/src/config.py
+++ b/src/config.py
@@ -5,6 +5,14 @@ from pathlib import Path
 from pydantic import Field, model_validator
 from pydantic_settings import BaseSettings, SettingsConfigDict
 
+FIELD_MAP: dict[str, str] = {
+    "request_delay_min": "request_delay_min",
+    "request_delay_max": "request_delay_max",
+    "page_load_timeout": "page_load_timeout",
+    "max_retries": "retry.max_attempts",
+    "retry_backoff": "retry.backoff_factor",
+}
+
 
 class RetrySettings(BaseSettings):
     """Retry configuration settings."""
@@ -64,60 +72,28 @@ class Settings(BaseSettings):
 
         This allows passing values like Settings(request_delay_min=0.5) directly
         while maintaining the nested scraping configuration structure.
+
+        Flat keys are mapped into the scraping dict as raw values. Pydantic
+        handles all type coercion and validation during normal construction.
         """
-        # Handle request_delay_min
-        if "request_delay_min" in values and values["request_delay_min"] is not None:
-            if "scraping" not in values:
-                values["scraping"] = ScrapingSettings()
-            raw_value = values.pop("request_delay_min")
-            try:
-                values["scraping"].request_delay_min = float(raw_value)
-            except (ValueError, TypeError):
-                values["scraping"].request_delay_min = raw_value
+        # Normalize scraping to a plain dict for mutation
+        if "scraping" not in values or values["scraping"] is None:
+            values["scraping"] = {}
+        elif isinstance(values["scraping"], ScrapingSettings):
+            values["scraping"] = values["scraping"].model_dump()
 
-        # Handle request_delay_max
-        if "request_delay_max" in values and values["request_delay_max"] is not None:
-            if "scraping" not in values:
-                values["scraping"] = ScrapingSettings()
-            raw_value = values.pop("request_delay_max")
-            try:
-                values["scraping"].request_delay_max = float(raw_value)
-            except (ValueError, TypeError):
-                values["scraping"].request_delay_max = raw_value
-
-        # Handle page_load_timeout
-        if "page_load_timeout" in values and values["page_load_timeout"] is not None:
-            if "scraping" not in values:
-                values["scraping"] = ScrapingSettings()
-            raw_value = values.pop("page_load_timeout")
-            try:
-                values["scraping"].page_load_timeout = int(raw_value)
-            except (ValueError, TypeError):
-                values["scraping"].page_load_timeout = raw_value
-
-        # Handle max_retries
-        if "max_retries" in values and values["max_retries"] is not None:
-            if "scraping" not in values:
-                values["scraping"] = ScrapingSettings()
-            if not hasattr(values["scraping"], "retry") or values["scraping"].retry is None:
-                values["scraping"].retry = RetrySettings()
-            raw_value = values.pop("max_retries")
-            try:
-                values["scraping"].retry.max_attempts = int(raw_value)
-            except (ValueError, TypeError):
-                values["scraping"].retry.max_attempts = raw_value
-
-        # Handle retry_backoff
-        if "retry_backoff" in values and values["retry_backoff"] is not None:
-            if "scraping" not in values:
-                values["scraping"] = ScrapingSettings()
-            if not hasattr(values["scraping"], "retry") or values["scraping"].retry is None:
-                values["scraping"].retry = RetrySettings()
-            raw_value = values.pop("retry_backoff")
-            try:
-                values["scraping"].retry.backoff_factor = float(raw_value)
-            except (ValueError, TypeError):
-                values["scraping"].retry.backoff_factor = raw_value
+        # Map each flat key into the nested dict structure
+        for flat_key, nested_path in FIELD_MAP.items():
+            if flat_key in values:
+                parts = nested_path.split(".")
+                target = values["scraping"]
+                for part in parts[:-1]:
+                    if part not in target or target[part] is None:
+                        target[part] = {}
+                    elif isinstance(target[part], (ScrapingSettings, RetrySettings)):
+                        target[part] = target[part].model_dump()
+                    target = target[part]
+                target[parts[-1]] = values.pop(flat_key)
 
         return values
 

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -454,70 +454,30 @@ class TestValidation:
         with pytest.raises(ValidationError):
             Settings(window_height="invalid")
 
-    def test_invalid_request_delay_min_coercion(self):
-        """Test that invalid request_delay_min type is accepted (bypasses validation).
+    def test_invalid_request_delay_min_raises_validation_error(self):
+        """Test that invalid request_delay_min raises ValidationError."""
+        with pytest.raises(ValidationError):
+            Settings(request_delay_min="invalid")
 
-        Note: Due to backwards-compat model_validator, invalid types are assigned
-        directly to nested ScrapingSettings, bypassing validation.
-        """
-        # Arrange & Act
-        config = Settings(request_delay_min="invalid")
+    def test_invalid_request_delay_max_raises_validation_error(self):
+        """Test that invalid request_delay_max raises ValidationError."""
+        with pytest.raises(ValidationError):
+            Settings(request_delay_max="invalid")
 
-        # Assert - the invalid value is stored as-is (no coercion)
-        assert config.request_delay_min == "invalid"
-        assert config.scraping.request_delay_min == "invalid"
+    def test_invalid_max_retries_raises_validation_error(self):
+        """Test that invalid max_retries raises ValidationError."""
+        with pytest.raises(ValidationError):
+            Settings(max_retries="invalid")
 
-    def test_invalid_request_delay_max_coercion(self):
-        """Test that invalid request_delay_max type is accepted (bypasses validation).
+    def test_invalid_retry_backoff_raises_validation_error(self):
+        """Test that invalid retry_backoff raises ValidationError."""
+        with pytest.raises(ValidationError):
+            Settings(retry_backoff="invalid")
 
-        Note: Due to backwards-compat model_validator, invalid types are assigned
-        directly to nested ScrapingSettings, bypassing validation.
-        """
-        # Arrange & Act
-        config = Settings(request_delay_max="invalid")
-
-        # Assert - the invalid value is stored as-is (no coercion)
-        assert config.request_delay_max == "invalid"
-        assert config.scraping.request_delay_max == "invalid"
-
-    def test_invalid_max_retries_coercion(self):
-        """Test that invalid max_retries type is accepted (bypasses validation).
-
-        Note: Due to backwards-compat model_validator, invalid types are assigned
-        directly to nested ScrapingSettings, bypassing validation.
-        """
-        # Arrange & Act
-        config = Settings(max_retries="invalid")
-
-        # Assert - the invalid value is stored as-is (no coercion)
-        assert config.max_retries == "invalid"
-        assert config.scraping.retry.max_attempts == "invalid"
-
-    def test_invalid_retry_backoff_coercion(self):
-        """Test that invalid retry_backoff type is accepted (bypasses validation).
-
-        Note: Due to backwards-compat model_validator, invalid types are assigned
-        directly to nested ScrapingSettings, bypassing validation.
-        """
-        # Arrange & Act
-        config = Settings(retry_backoff="invalid")
-
-        # Assert - the invalid value is stored as-is (no coercion)
-        assert config.retry_backoff == "invalid"
-        assert config.scraping.retry.backoff_factor == "invalid"
-
-    def test_invalid_page_load_timeout_coercion(self):
-        """Test that invalid page_load_timeout type is accepted (bypasses validation).
-
-        Note: Due to backwards-compat model_validator, invalid types are assigned
-        directly to nested ScrapingSettings, bypassing validation.
-        """
-        # Arrange & Act
-        config = Settings(page_load_timeout="invalid")
-
-        # Assert - the invalid value is stored as-is (no coercion)
-        assert config.page_load_timeout == "invalid"
-        assert config.scraping.page_load_timeout == "invalid"
+    def test_invalid_page_load_timeout_raises_validation_error(self):
+        """Test that invalid page_load_timeout raises ValidationError."""
+        with pytest.raises(ValidationError):
+            Settings(page_load_timeout="invalid")
 
     def test_negative_window_width_accepted(self):
         """Test that negative window_width is accepted (no validation)."""


### PR DESCRIPTION
## Summary

Refactors the \`map_backwards_compatibility_fields\` model_validator to keep \`values['scraping']\` as a plain dict instead of mutating constructed Pydantic model instances. This lets Pydantic handle all type coercion and validation during normal \`Settings\` construction.

## Changes

- **Added** \`FIELD_MAP\` constant for declarative flat-to-nested field mapping
- **Replaced** 62-line manual validator with a clean dict-based approach (~30 lines)
- **Updated** 5 invalid coercion tests to assert \`ValidationError\` instead of silently accepting invalid values

## Fixes

Fixes #18

## Verification

- Full test suite: 707 passed, 0 regressions (12 pre-existing failures unrelated)
- \`src/config.py\` coverage: 98% (up from 75%)
- Ruff linting: ✅ passed
- Mypy type check: ✅ passed